### PR TITLE
use a local repo instead of dpkg -i *

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,51 +2,29 @@ FROM ubuntu:16.04
 MAINTAINER Péter Nagy <nagylakas@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG="C"
 
 RUN rm -f /etc/localtime \
  && ln -s /usr/share/zoneinfo/Europe/Budapest /etc/localtime \
  && echo "Europe/Budapest" > /etc/timezone \
  && apt-get update \
- && apt-get -y dist-upgrade
+ && apt-get -y dist-upgrade \
+ && apt-get install -y curl lynx apt-utils \
+ && rm -rf /var/cache/apt /var/lib/apt/lists
 
+RUN mkdir -p /tmp/repo
+WORKDIR /tmp/repo
+
+RUN curl -L `lynx -listonly -nonumbers -dump https://download.kopano.io/community/core:/ | grep Ubuntu_16.04-amd64.tar.gz` | tar -xz --strip-components 1 -f -
+RUN curl -L `lynx -listonly -nonumbers -dump https://download.kopano.io/community/webapp:/ | grep Ubuntu_16.04-all.tar.gz` | tar -xz --strip-components 1 -f -
+
+RUN apt-ftparchive packages . | gzip -9c > Packages.gz && echo "deb file:/tmp/repo ./" > /etc/apt/sources.list.d/kopano.list
 RUN apt-get update \
- && apt-get upgrade \
- && apt-get -y install curl locales \
-    apache2 php libapache2-mod-php xapian-tools \
-    libpython2.7 python python-flask python-sleekxmpp python-xapian libical1a \
-    bash-completion mktemp gawk w3m xsltproc poppler-utils unzip catdoc \
-    libboost-filesystem1.58.0 libboost-system1.58.0 libtcmalloc-minimal4 libmysqlclient20 \
-    libdigest-hmac-perl libfile-copy-recursive-perl \
-    libunicode-string-perl libreadonly-perl \
-    libio-tee-perl libmail-imapclient-perl libcurl3 \
-    gnutls-bin language-pack-en language-pack-hu \
-    supervisor openssh-server php-enchant php-xml \
-    php-gettext php-zip \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-COPY kopano-init.sh /usr/local/bin/
-COPY kopano-start.sh /usr/local/bin/
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-WORKDIR /tmp
-
-ENV LANG="C"
-ENV KOPANOVER="8.4.90.34_0+14-Ubuntu_16.04-amd64"
-
-RUN curl -L https://download.kopano.io/community/core:/core-${KOPANOVER}.tar.gz | tar xzv 
-RUN cd core-$KOPANOVER \
-    && ls -1 *.deb | egrep -v '(-dev_|-dbg_|-doc_)' | xargs dpkg -i \
-    && cd - \
-    && rm -rf core-$KOPANOVER
-
-
-ENV KOPANO_WEBAPPVERSION="3.4.0.770_0+519-Ubuntu_16.04-all"
-RUN curl -L https://download.kopano.io/community/webapp:/webapp-$KOPANO_WEBAPPVERSION.tar.gz | tar xzv \
-  && cd webapp-$KOPANO_WEBAPPVERSION \
-  && dpkg -i *.deb \
-  && cd - \
-  && rm -rf webapp-$KOPANO_WEBAPPVERSION
+ && apt-get install -y --allow-unauthenticated \
+ kopano-server-packages \
+ kopano-webapp \
+ kopano-webapp-plugin-titlecounter \
+ && rm -rf /var/cache/apt /var/lib/apt/lists
 
 RUN curl -L http://repo.z-hub.io/z-push:/final/Ubuntu_16.04/Release.key | apt-key add - \
  && echo "deb http://repo.z-hub.io/z-push:/final/Ubuntu_16.04/ /" > /etc/apt/sources.list.d/z-push.list \
@@ -54,6 +32,10 @@ RUN curl -L http://repo.z-hub.io/z-push:/final/Ubuntu_16.04/Release.key | apt-ke
  && apt-get -y install z-push-kopano z-push-config-apache \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+COPY kopano-init.sh /usr/local/bin/
+COPY kopano-start.sh /usr/local/bin/
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 CMD ["/usr/local/bin/kopano-start.sh"]
 


### PR DESCRIPTION
Hi,

I just found you repo in Github.

The downloads on download.kopano.io/community are nightly builds which will change on a regular base. therefore its better to dynamically grep the latest download archive. additionally i have added added code to create a local apt repo from the download so you don't have to reply on manually fetching the package dependencies upfront. 

Regards Felix